### PR TITLE
Enable public url sharing

### DIFF
--- a/WebPortal/Components/FileGridComponents/FileGridFiles.razor
+++ b/WebPortal/Components/FileGridComponents/FileGridFiles.razor
@@ -40,15 +40,15 @@
                     <i class="far fa-info-circle icon-color sm-icon"></i>
                     @Localizer["ViewDetails"]
                 </a>
-                <AuthorizeView Roles="DHPGLIST-admin">
-                    @if (!string.IsNullOrEmpty(Project))
-                    {
-                        <a @onclick=@ShareFile>
-                            <i class="far fa-share-square icon-color sm-icon"></i>
-                            @Localizer["Share"]
-                        </a>
-                    }
-                </AuthorizeView>
+                
+                @if (!string.IsNullOrEmpty(Project))
+                {
+                    <a @onclick=@ShareFile>
+                        <i class="far fa-share-square icon-color sm-icon"></i>
+                        @Localizer["Share"]
+                    </a>
+                }
+
 <!-- To be added when we support it
                 <a @onclick="OpenVersions">
                     <i class="fas fa-code-branch icon-color sm-icon"></i>

--- a/WebPortal/Components/FileGridComponents/FileGridMenu.razor
+++ b/WebPortal/Components/FileGridComponents/FileGridMenu.razor
@@ -10,11 +10,9 @@
 
 @if (IsProject)
 {
-    <AuthorizeView Roles="DHPGLIST-admin">
-        <FileGridMenuButton IconClass="far fa-share-square" Enabled="IsFile" OnClick="Share">
-            @Localizer["Share"]
-        </FileGridMenuButton>
-    </AuthorizeView>
+    <FileGridMenuButton IconClass="far fa-share-square" Enabled="IsFile" OnClick="Share">
+        @Localizer["Share"]
+    </FileGridMenuButton>
 }
 
 <FileGridMenuButton IconClass="far fa-info-circle" Enabled="IsFile" OnClick="OpenDetails">

--- a/WebPortal/Pages/DataProject.razor
+++ b/WebPortal/Pages/DataProject.razor
@@ -255,27 +255,25 @@
                 </Footer>
             </AeCard>
 
-            <AuthorizeView Roles="DHPGLIST-admin" Context="hidden_in_dev">
-                <AeCard class="facard1" CardPosition="AeCard.CardStyle.Horizontal">
-                    <Header>
-                        <div>
-                            <AeIcon class="fad fa-share-square card-icon"/>
-                        </div>
-                    </Header>
-                    <ChildContent>
-                        <DHLink Variant="h3" DataProject="@projectAcronym" LinkType="DatahubLinkType.DataSharingDashboard">
-                            @Localizer["PROJECT-PAGE.PUBLIC-SHARING-CARD.Title"]
-                        </DHLink>
-                        <AeTypography>@Localizer["PROJECT-PAGE.PUBLIC-SHARING-CARD.UsersOwnSharedFiles"]: @_ownSharingRequestCount</AeTypography>
-                            @if(_isDataApprover)
-                            {
-                                <AeTypography>
-                                    @Localizer["PROJECT-PAGE.PUBLIC-SHARING-CARD.SharedFilesAwaitingApproval"]: @_sharingRequestAwaitingApprovalCount
-                                </AeTypography>
-                            }
-                    </ChildContent>
-                </AeCard>
-            </AuthorizeView>
+            <AeCard class="facard1" CardPosition="AeCard.CardStyle.Horizontal">
+                <Header>
+                    <div>
+                        <AeIcon class="fad fa-share-square card-icon"/>
+                    </div>
+                </Header>
+                <ChildContent>
+                    <DHLink Variant="h3" DataProject="@projectAcronym" LinkType="DatahubLinkType.DataSharingDashboard">
+                        @Localizer["PROJECT-PAGE.PUBLIC-SHARING-CARD.Title"]
+                    </DHLink>
+                    <AeTypography>@Localizer["PROJECT-PAGE.PUBLIC-SHARING-CARD.UsersOwnSharedFiles"]: @_ownSharingRequestCount</AeTypography>
+                        @if(_isDataApprover)
+                        {
+                            <AeTypography>
+                                @Localizer["PROJECT-PAGE.PUBLIC-SHARING-CARD.SharedFilesAwaitingApproval"]: @_sharingRequestAwaitingApprovalCount
+                            </AeTypography>
+                        }
+                </ChildContent>
+            </AeCard>
 
             <AuthorizeView Roles="@($"{projectAcronym}-admin")" Context="Project_Cost">
                 <AeCard class="facard1" CardPosition="AeCard.CardStyle.Horizontal">

--- a/WebPortal/Pages/SharingWorkflow.razor
+++ b/WebPortal/Pages/SharingWorkflow.razor
@@ -8,36 +8,36 @@
 
 <div style="padding-left: 2rem;padding-right: 2rem">
     <AeFlex Vertical>
-        <AeTypography Variant="h1">Data Sharing</AeTypography>
+        <AeTypography Variant="h1">@Localizer[$"{LOCALIZATION_PREFIX}.Title"]</AeTypography>
     </AeFlex>
     
     <AuthorizeView Roles="DHPGLIST-admin" Context="hidden_in_dev">
     <AeCard>
         <Header>
-        <AeTypography Variant="h1">@Localizer["Share Data in Canada Open Data Portal"]</AeTypography>
+        <AeTypography Variant="h1">@Localizer[$"{LOCALIZATION_PREFIX}.OpenDataTitle"]</AeTypography>
         </Header>
         <ChildContent>
             <p>
-                This workflow will enable to upload your data to the Canada Open Data Portal. It includes the metadata management and approvals.
+                @Localizer[$"{LOCALIZATION_PREFIX}.OpenDataDesc"]
             </p>
         </ChildContent>
         <Footer>
-            <AeButton OnClickEvent=@OpenDataClicked Disabled=@_openDataDisabled >@Localizer["Start Workflow"]</AeButton>
+            <AeButton OnClickEvent=@OpenDataClicked Disabled=@_openDataDisabled >@Localizer[$"{LOCALIZATION_PREFIX}.StartWorkflowButton"]</AeButton>
 		</Footer>
     </AeCard>
     </AuthorizeView>
     
     <AeCard>
         <Header>
-        <AeTypography Variant="h1">@Localizer["Share Data using DataHub public URLs"]</AeTypography>
+        <AeTypography Variant="h1">@Localizer[$"{LOCALIZATION_PREFIX}.PublicUrlTitle"]</AeTypography>
         </Header>
         <ChildContent>
             <p>
-                This workflow will generate public links (data-nrcan.canada.ca, donnees-rncan.canada.ca) from your files to reference them on external sites or publications.
+                @Localizer[$"{LOCALIZATION_PREFIX}.PublicUrlDesc"]
             </p>
         </ChildContent>
         <Footer>
-            <AeButton OnClickEvent=@PublicUrlClicked Disabled=@_publicUrlDisabled >@Localizer["Start Workflow"]</AeButton>
+            <AeButton OnClickEvent=@PublicUrlClicked Disabled=@_publicUrlDisabled >@Localizer[$"{LOCALIZATION_PREFIX}.StartWorkflowButton"]</AeButton>
 		</Footer>
     </AeCard>
 </div>
@@ -45,6 +45,8 @@
 
 
 @code {
+
+    private static readonly string LOCALIZATION_PREFIX = "PUBLIC-SHARING-WORKFLOW";
 
     [Parameter]
     public string FileId { get; set; }

--- a/WebPortal/Pages/SharingWorkflow.razor
+++ b/WebPortal/Pages/SharingWorkflow.razor
@@ -10,6 +10,8 @@
     <AeFlex Vertical>
         <AeTypography Variant="h1">Data Sharing</AeTypography>
     </AeFlex>
+    
+    <AuthorizeView Roles="DHPGLIST-admin" Context="hidden_in_dev">
     <AeCard>
         <Header>
         <AeTypography Variant="h1">@Localizer["Share Data in Canada Open Data Portal"]</AeTypography>
@@ -23,6 +25,8 @@
             <AeButton OnClickEvent=@OpenDataClicked Disabled=@_openDataDisabled >@Localizer["Start Workflow"]</AeButton>
 		</Footer>
     </AeCard>
+    </AuthorizeView>
+    
     <AeCard>
         <Header>
         <AeTypography Variant="h1">@Localizer["Share Data using DataHub public URLs"]</AeTypography>
@@ -33,7 +37,7 @@
             </p>
         </ChildContent>
         <Footer>
-            <AeButton OnClickEvent=@PublicUrlClicked Disabled=@_openDataDisabled >@Localizer["Start Workflow"]</AeButton>
+            <AeButton OnClickEvent=@PublicUrlClicked Disabled=@_publicUrlDisabled >@Localizer["Start Workflow"]</AeButton>
 		</Footer>
     </AeCard>
 </div>

--- a/WebPortal/i18n/localization.json
+++ b/WebPortal/i18n/localization.json
@@ -585,6 +585,15 @@
     }
   },
 
+  "PUBLIC-SHARING-WORKFLOW": {
+    "Title": "Data Sharing",
+    "OpenDataTitle": "Share Data in Canada Open Data Portal",
+    "OpenDataDesc": "This workflow will enable to upload your data to the Canada Open Data Portal. It includes the metadata management and approvals.",
+    "StartWorkflowButton": "Start Workflow",
+    "PublicUrlTitle": "Share Data using DataHub public URLs",
+    "PublicUrlDesc": "This workflow will generate public links (data-nrcan.canada.ca, donnees-rncan.canada.ca) from your files to reference them on external sites or publications."
+  },
+
   "DATA-SHARING-DASHBOARD": {
     "Title": "Data Sharing Dashboard",
     "RequestsPendingApproval": "Public URL Sharing Requests Pending Approval",


### PR DESCRIPTION
This enables public sharing through Storage Explorer, but hides the Open Data option for anyone other than DataHub admins. Once that's finished and working we can remove that restriction.