### PR TITLE
Anonymous user update

### DIFF
--- a/Datahub.Core/Services/IUserInformationService.cs
+++ b/Datahub.Core/Services/IUserInformationService.cs
@@ -24,5 +24,21 @@ namespace Datahub.Core.Services
         public static readonly string ANONYMOUS_USER_ID = "c90acba3-26e4-471d-bbdf-544906e6a980";
         public static readonly string ANONYMOUS_USER_NAME = "Anonymous User";
         public static readonly string ANONYMOUS_USER_EMAIL = "anyone@example.com";
+
+        private static User _anonymousUser;
+        public static User GetAnonymousUser()
+        {
+            if (_anonymousUser == null)
+            {
+                _anonymousUser = new User()
+                {
+                    Id = ANONYMOUS_USER_ID,
+                    Mail = ANONYMOUS_USER_EMAIL,
+                    DisplayName = ANONYMOUS_USER_NAME,
+                    UserPrincipalName = ANONYMOUS_USER_EMAIL
+                };
+            }
+            return _anonymousUser;
+        }
     }
 }

--- a/Datahub.Core/Services/MSGraphService.cs
+++ b/Datahub.Core/Services/MSGraphService.cs
@@ -111,6 +111,14 @@ namespace Datahub.Core.Services
                         }
                     }
 
+                    // add anonymous user
+                    var anonUser = UserInformationServiceConstants.GetAnonymousUser();
+                    if (anonUser != null)
+                    {
+                        var newUser = GraphUser.Create(anonUser);
+                        UsersDict.Add(newUser.Id, newUser);
+                    }
+
                     //var user1 = UsersDict.Values.Where(u => u.Mail.ToLower() == "natasha.lestage@nrcan-rncan.gc.ca").FirstOrDefault().Id;
                     
                     

--- a/Datahub.Core/Services/Offline/OfflineUserInformationService.cs
+++ b/Datahub.Core/Services/Offline/OfflineUserInformationService.cs
@@ -8,25 +8,7 @@ namespace Datahub.Core.Services
     {
         readonly ILogger<IUserInformationService> _logger;
 
-        private User _anonymousUser;
-        private User AnonymousUser
-        {
-            get
-            {
-                if (_anonymousUser == null)
-                {
-                    _anonymousUser = new User()
-                    {
-                        Id = UserInformationServiceConstants.ANONYMOUS_USER_ID,
-                        Mail = UserInformationServiceConstants.ANONYMOUS_USER_EMAIL,
-                        DisplayName = UserInformationServiceConstants.ANONYMOUS_USER_NAME,
-                        UserPrincipalName = UserInformationServiceConstants.ANONYMOUS_USER_EMAIL
-                    };
-                }
-
-                return _anonymousUser;
-            }
-        }
+        private User AnonymousUser => UserInformationServiceConstants.GetAnonymousUser();
 
         public OfflineUserInformationService(ILogger<IUserInformationService> logger)
         {

--- a/Datahub.Core/Services/UserInformationService.cs
+++ b/Datahub.Core/Services/UserInformationService.cs
@@ -30,26 +30,7 @@ namespace Datahub.Core.Services
         
         public User CurrentUser { get; set; }
 
-        private User _anonymousUser;
-        private User AnonymousUser
-        {
-            get
-            {
-                if (_anonymousUser == null)
-                {
-                    _anonymousUser = new User()
-                    {
-                        Id = UserInformationServiceConstants.ANONYMOUS_USER_ID,
-                        Mail = UserInformationServiceConstants.ANONYMOUS_USER_EMAIL,
-                        DisplayName = UserInformationServiceConstants.ANONYMOUS_USER_NAME,
-                        UserPrincipalName = UserInformationServiceConstants.ANONYMOUS_USER_EMAIL
-                    };
-                }
-
-                return _anonymousUser;
-            }
-        }
-
+        private User AnonymousUser => UserInformationServiceConstants.GetAnonymousUser();
 
         public UserInformationService(
             ILogger<UserInformationService> logger,


### PR DESCRIPTION
Since MSGraphService has no connection to UserInformationService, I moved the anonymous user definition to a static class where it's available to both services. In the future we can look up the anonymous user, e.g. if we show data logs in the admin section