### PR TITLE
Breadcrumbs

### DIFF
--- a/Datahub.Core/Components/TopBar/Breadcrumbs.razor
+++ b/Datahub.Core/Components/TopBar/Breadcrumbs.razor
@@ -1,0 +1,76 @@
+@*Breadcrumbs.razor*@
+@implements IDisposable
+@inherits LayoutComponentBase
+@using MudBlazor
+@using System.Globalization
+
+<MudBreadcrumbs Items="@_items" MaxItems="7" Separator=">"></MudBreadcrumbs>
+
+@code {
+
+    [Inject]
+    NavigationManager _navigationManager { get; set; }
+
+    [Parameter]
+    public List<BreadcrumbItem> _items { get; set; }
+
+    private CultureInfo _cultureInfo = Thread.CurrentThread.CurrentCulture;
+
+    private string _currentPath;
+
+    protected override void OnInitialized()
+    {
+        _navigationManager.LocationChanged += OnLocationChanged;
+        var relativeLocation = _navigationManager.ToBaseRelativePath(_navigationManager.Uri);
+
+    //Set new breadcrumb items on each invocation
+        SetBreadcrumbs(relativeLocation);
+
+        base.OnInitialized();
+    }
+
+    private void OnLocationChanged(object sender, LocationChangedEventArgs e)
+    {
+        var relativeLocation = _navigationManager.ToBaseRelativePath(e.Location);
+        SetBreadcrumbs(relativeLocation);
+    }
+
+    private void SetBreadcrumbs(string relativeLocation)
+    {
+        _items = new List<BreadcrumbItem>
+        {
+    // Government of Canada Base Path
+            new(
+                href: @Localizer["https://www.canada.ca/en.html"],
+                text: "Canada.ca"
+                )
+        };
+
+        _currentPath = _navigationManager.Uri;
+        var url = _currentPath.Replace(_navigationManager.BaseUri, "");
+        _items.Add(new BreadcrumbItem(
+            href: _navigationManager.BaseUri,
+            disabled: _currentPath == _navigationManager.BaseUri,
+            text: @Localizer[_cultureInfo.TextInfo.ToTitleCase("Home")]
+            ));
+
+        var path = url.Split('/');
+        foreach (var link in path)
+        {
+            if (link == "home") continue;
+
+            _items.Add(new BreadcrumbItem(
+                href: $"{_items.Last().Href}/{link}",
+                disabled: link == path.Last(),
+                text: _cultureInfo.TextInfo.ToTitleCase(link)
+                ));
+        }
+        StateHasChanged();
+    }
+
+    void IDisposable.Dispose()
+    {
+        _navigationManager.LocationChanged -= OnLocationChanged;
+    }
+
+}

--- a/Datahub.Core/Components/TopBar/Breadcrumbs.razor
+++ b/Datahub.Core/Components/TopBar/Breadcrumbs.razor
@@ -4,66 +4,67 @@
 @using MudBlazor
 @using System.Globalization
 
-<MudBreadcrumbs Items="@_items" MaxItems="7" Separator=">"></MudBreadcrumbs>
+<MudBreadcrumbs Items="@_items" MaxItems="7" Separator=">"/>
 
 @code {
 
     [Inject]
-    NavigationManager _navigationManager { get; set; }
+    private NavigationManager _navigationManager { get; set; }
 
     [Parameter]
     public List<BreadcrumbItem> _items { get; set; }
 
-    private CultureInfo _cultureInfo = Thread.CurrentThread.CurrentCulture;
-
-    private string _currentPath;
+    private TextInfo _textInfo = CultureInfo.CurrentCulture.TextInfo;
+    private string _lang = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
 
     protected override void OnInitialized()
     {
         _navigationManager.LocationChanged += OnLocationChanged;
-        var relativeLocation = _navigationManager.ToBaseRelativePath(_navigationManager.Uri);
+        var relativePath = _navigationManager.ToBaseRelativePath(_navigationManager.Uri);
 
-    //Set new breadcrumb items on each invocation
-        SetBreadcrumbs(relativeLocation);
+    // Set new breadcrumb items on each invocation
+        SetBreadcrumbs(relativePath);
 
         base.OnInitialized();
     }
 
     private void OnLocationChanged(object sender, LocationChangedEventArgs e)
     {
-        var relativeLocation = _navigationManager.ToBaseRelativePath(e.Location);
-        SetBreadcrumbs(relativeLocation);
+        var relativePath = _navigationManager.ToBaseRelativePath(e.Location);
+        SetBreadcrumbs(relativePath);
     }
 
-    private void SetBreadcrumbs(string relativeLocation)
+    private void SetBreadcrumbs(string path)
     {
+        var pathItems = path.Split('/');
+
+    // Always initialize with GoC and Home as base breadcrumb
         _items = new List<BreadcrumbItem>
         {
     // Government of Canada Base Path
             new(
-                href: @Localizer["https://www.canada.ca/en.html"],
+                href: $"https://www.canada.ca/{_lang}.html",
                 text: "Canada.ca"
+                ),
+            new(
+                href: "/home",
+                disabled: "home" == pathItems.Last(),
+                text: @Localizer["Home"]
                 )
         };
 
-        _currentPath = _navigationManager.Uri;
-        var url = _currentPath.Replace(_navigationManager.BaseUri, "");
-        _items.Add(new BreadcrumbItem(
-            href: _navigationManager.BaseUri,
-            disabled: _currentPath == _navigationManager.BaseUri,
-            text: @Localizer[_cultureInfo.TextInfo.ToTitleCase("Home")]
-            ));
-
-        var path = url.Split('/');
-        foreach (var link in path)
+    // keep track of previous crumbs to avoid appending /home
+        var prev = "";
+        foreach (var crumb in pathItems)
         {
-            if (link == "home") continue;
-
+            if (crumb == "home") continue;
+            var crumbText = _textInfo.ToTitleCase(crumb);
             _items.Add(new BreadcrumbItem(
-                href: $"{_items.Last().Href}/{link}",
-                disabled: link == path.Last(),
-                text: _cultureInfo.TextInfo.ToTitleCase(link)
+                href: $"{prev}/{crumb}",
+                disabled: crumb == pathItems.Last(),
+                text: @Localizer[crumbText]
                 ));
+            prev += $"/{crumb}";
         }
         StateHasChanged();
     }

--- a/Datahub.Core/Components/TopBar/Topbar.razor
+++ b/Datahub.Core/Components/TopBar/Topbar.razor
@@ -6,6 +6,7 @@
     <MudText Typo="Typo.h6" Style="@_titleStyle">
         @Localizer["MainTitle"]
     </MudText>
+    <Breadcrumbs></Breadcrumbs>
 </MudStack>
 
 <MudSpacer/>

--- a/Datahub.Core/Components/TopBar/Topbar.razor
+++ b/Datahub.Core/Components/TopBar/Topbar.razor
@@ -6,7 +6,7 @@
     <MudText Typo="Typo.h6" Style="@_titleStyle">
         @Localizer["MainTitle"]
     </MudText>
-    <Breadcrumbs></Breadcrumbs>
+    <Breadcrumbs/>
 </MudStack>
 
 <MudSpacer/>


### PR DESCRIPTION
Added dynamic breadcrumbs to Topbar

Names are appropriately localized, see screenshots:

English:

![image](https://user-images.githubusercontent.com/15817372/195704321-a7027349-2d3b-4bcd-b959-e83b96e98233.png)


![image](https://user-images.githubusercontent.com/15817372/195704379-9f63770a-3150-4fb6-aa69-cb044092aab9.png)

French:

![image](https://user-images.githubusercontent.com/15817372/195704466-0ce663b5-f1cf-4aa0-a082-b0b578b27c84.png)

OnClick leads to: `https://www.canada.ca/fr.html`