### PR TITLE
Edit Initiative Metadata after creation

### DIFF
--- a/Datahub.Core/Model/Onboarding/Onboarding_Constants.cs
+++ b/Datahub.Core/Model/Onboarding/Onboarding_Constants.cs
@@ -2,21 +2,19 @@
 {
     public class Onboarding_Constants
     {
-        public static readonly string[] CATEGORY = { "Data Pipeline",
-                                                    "Data Science",
-                                                    "Full Stack",
-                                                    "Guidance",
-                                                    "Power BI Reports",
-                                                    "Storage",
-                                                    "Web Forms",
-                                                    "Unknown",
-                                                    "Other"
+        public static readonly string[] CATEGORY =
+        {
+            "Data Pipeline",
+            "Data Science",
+            "Full Stack",
+            "Guidance",
+            "Power BI Reports",
+            "Storage",
+            "Web Forms",
+            "Unknown",
+            "Other"
         };
 
-        public static readonly string[] SECURITYLEVEL = {   "Classified", 
-                                                            "Protected A",
-                                                            "Protected B",
-                                                            "Protected C",
-                                                            "Unclassified",};
-}
+        public static readonly string[] SECURITYLEVEL = { "Unclassified", "Protected A", "Protected B", "Protected C" };
+    }
 }

--- a/Datahub.Core/SecurityClassification.cs
+++ b/Datahub.Core/SecurityClassification.cs
@@ -5,7 +5,7 @@ public static class SecurityClassification
     public const string Unclassified = "Unclassified";
     public const string ProtectedA = "Protected A";
     public const string ProtectedB = "Protected B";
-    public static readonly string[] SECURITY_CLASSES = { Unclassified, ProtectedA, ProtectedB };
+    public const string ProtectedC = "Protected C";
 
     public static string GetSecurityClassification(ClassificationType classificationType)
     {

--- a/Datahub.Core/Services/IOrganizationLevelsService.cs
+++ b/Datahub.Core/Services/IOrganizationLevelsService.cs
@@ -14,5 +14,5 @@ namespace Datahub.Core.Services
         Task<OrganizationLevel> GetBranch(int branchId);
     }
 
-    public record OrganizationLevel(int Id, int ParentId, string EnglishLabel, string FrenchLabel);
+    public record OrganizationLevel(int Id, int ParentId, string EnglishLabel, string FrenchLabel, string EnglishAcronym, string FrenchAcronym);
 }

--- a/Datahub.Core/Services/OrganizationLevelsService.cs
+++ b/Datahub.Core/Services/OrganizationLevelsService.cs
@@ -33,7 +33,7 @@ namespace Datahub.Core.Services
             using var ctx = _dbContextFactory.CreateDbContext();
             return await ctx.Organization_Levels
                 .Where(l => l.Org_Level == level)
-                .Select(l => new OrganizationLevel(l.Organization_ID, l.Superior_OrgId ?? 0, l.Org_Name_E, l.Org_Name_F))
+                .Select(l => new OrganizationLevel(l.Organization_ID, l.Superior_OrgId ?? 0, l.Org_Name_E, l.Org_Name_F, l.Org_Acronym_E, l.Org_Acronym_F))
                 .ToListAsync();
         }
 
@@ -42,7 +42,7 @@ namespace Datahub.Core.Services
             using var ctx = await _dbContextFactory.CreateDbContextAsync();
             return await ctx.Organization_Levels
                 .Where(l => l.Organization_ID == id && l.Org_Level == level)
-                .Select(l => new OrganizationLevel(l.Organization_ID, l.Superior_OrgId ?? 0, l.Org_Name_E, l.Org_Name_F))
+                .Select(l => new OrganizationLevel(l.Organization_ID, l.Superior_OrgId ?? 0, l.Org_Name_E, l.Org_Name_F, l.Org_Acronym_E, l.Org_Acronym_F))
                 .FirstOrDefaultAsync();
         }
 

--- a/Datahub.Metadata/Model/ClassificationType.cs
+++ b/Datahub.Metadata/Model/ClassificationType.cs
@@ -4,6 +4,7 @@
     { 
         Unclassified,
         ProtectedA,
-        ProtectedB  
+        ProtectedB,
+        ProtectedC
     }
 }

--- a/WebPortal/Components/Metadata/ObjectMetadataEditor.razor
+++ b/WebPortal/Components/Metadata/ObjectMetadataEditor.razor
@@ -296,6 +296,7 @@
         {
             SecurityClassification.ProtectedA => ClassificationType.ProtectedA,
             SecurityClassification.ProtectedB => ClassificationType.ProtectedB,
+            SecurityClassification.ProtectedC => ClassificationType.ProtectedC,
             _ => ClassificationType.Unclassified
         };
     }

--- a/WebPortal/Pages/Admin/PowerBIAdmin.razor
+++ b/WebPortal/Pages/Admin/PowerBIAdmin.razor
@@ -136,6 +136,7 @@
                                     OnValuesChanged=@(() => StateHasChanged())
                                     @ref=@_workspaceMetadata
                                     DefaultMetadataId=@GetProjectMetadataUid(WorkspaceBeingEdited.ProjectId)
+                                    ProjectId=WorkspaceBeingEdited.ProjectId
                                     OnNewMetadataCreated=@AutoFillNewMetadataFields
                                     OnExistingMetadataLoaded=@DetectIfCurrentItemIsInCatalog
                                 />
@@ -184,6 +185,7 @@
                                     ValidateRequired
                                     OnValuesChanged=@(() => StateHasChanged())
                                     DefaultMetadataId=@GetProjectMetadataUid(DatasetBeingEdited.ProjectId)
+                                    ProjectId=WorkspaceBeingEdited.ProjectId
                                     @ref=@_datasetMetadata
                                     OnNewMetadataCreated=@AutoFillNewMetadataFields
                                     OnExistingMetadataLoaded=@DetectIfCurrentItemIsInCatalog
@@ -236,6 +238,7 @@
                                     CatalogLanguage=@_catalogObjectLanguage
                                     OnValuesChanged=@(() => StateHasChanged())
                                     DefaultMetadataId=@GetProjectMetadataUid(ReportBeingEdited.ProjectId)
+                                    ProjectId=WorkspaceBeingEdited.ProjectId
                                     OnNewMetadataCreated=@AutoFillNewMetadataFields
                                     OnExistingMetadataLoaded=@DetectIfCurrentItemIsInCatalog
                                 />

--- a/WebPortal/Pages/Admin/ProjectObjectMetadata.razor
+++ b/WebPortal/Pages/Admin/ProjectObjectMetadata.razor
@@ -74,8 +74,18 @@
 
     private int? FindOrganizationLevelId(List<OrganizationLevel> levels, string value) 
     {
-        var org = !string.IsNullOrEmpty(value) ? levels.FirstOrDefault(l => value.Equals(l.EnglishLabel, StringComparison.OrdinalIgnoreCase) || value.Equals(l.FrenchLabel, StringComparison.OrdinalIgnoreCase)) : null;
-        return org?.Id;
+        if (!string.IsNullOrEmpty(value))
+            return levels.FirstOrDefault(l => MatchesLevelWithName(l, value))?.Id;
+        return default;
+    }
+
+    private bool MatchesLevelWithName(OrganizationLevel level, string value)
+    {
+        var mode = StringComparison.OrdinalIgnoreCase;
+        return value.Equals(level.EnglishLabel, mode) || 
+               value.Equals(level.FrenchLabel, mode) ||
+               value.Equals(level.EnglishAcronym, mode) ||
+               value.Equals(level.FrenchAcronym, mode);
     }
 
     private void OnMetadataCreated()
@@ -104,6 +114,7 @@
             "CLASSIFIED" or
             "PROTECTED B" => SecurityClassification.ProtectedB,
             "PROTECTED A" => SecurityClassification.ProtectedA,
+            "PROTECTED C" => SecurityClassification.ProtectedC,
             _ => SecurityClassification.Unclassified
         };
     }

--- a/WebPortal/Pages/Forms/Internal/OnboardingApplication.razor
+++ b/WebPortal/Pages/Forms/Internal/OnboardingApplication.razor
@@ -5,7 +5,6 @@
 @inject ServiceAuthManager ServiceAuthManager
 @inject IDbContextFactory<DatahubProjectDBContext> DbFactory
 @inject IUserInformationService UserInformationService
-@inject NavigationManager NavigationManager
 @inject IJSRuntime JsInterop
 @inject UIControlsService UI
 @inject IDatahubAuditingService AuditingService
@@ -155,17 +154,21 @@
             {
                 Localizer[$"The program acronym already exists, enter a different one."]
             };
-            await UI.ToggleModal(
-    @<WarningModal OnDecision="HandleWarningDecision" WarningTextString=@textList />
-    );
+            await UI.ToggleModal(@<WarningModal OnDecision="HandleWarningDecision" WarningTextString=@textList/>);
         }
         else
         {
             _submittingApproval = true;
-            var orgAcronym = Context.Organization_Levels.Where(s => s.Org_Name_E == _onboardingApplication.Client_Sector).Select(a => a.Org_Acronym_E).FirstOrDefault();
+
+            // pick the sector acronym
+            var orgAcronym = Context.Organization_Levels
+                .Where(s => s.Org_Name_E == _onboardingApplication.Client_Sector || s.Org_Name_F == _onboardingApplication.Client_Sector)
+                .Select(a => a.Org_Acronym_E)
+                .FirstOrDefault();
+
             var project = new Datahub_Project();
             project.Project_Acronym_CD = _newProjectAcronym;
-            project.Sector_Name = orgAcronym;
+            project.Sector_Name = orgAcronym ?? _onboardingApplication.Client_Sector;
             project.Branch_Name = _onboardingApplication.Client_Branch;
             project.Division_Name = _onboardingApplication.Client_Division;
             project.Contact_List = CreateContactList();
@@ -190,8 +193,8 @@
             else
             {
                 await _submitApprovalInd.SignalSuccess();
+                NavigationManager.NavigateTo($"/admin/metadata/{_newProjectAcronym}");
             }
-
         }
     }
 

--- a/WebPortal/Pages/PowerBI/PowerBiReportMetadataEditor.razor
+++ b/WebPortal/Pages/PowerBI/PowerBiReportMetadataEditor.razor
@@ -2,6 +2,7 @@
 @inject IPowerBiDataService _powerBiDataService
 @inject TranslationService _translationService
 @inject IMetadataBrokerService _metadataService
+@inject IDbContextFactory<DatahubProjectDBContext> _projectDbFactory
 
 @if (_report == null)
 {
@@ -37,6 +38,7 @@ else
                 CatalogLanguage=@_catalogObjectLanguage
                 OnValuesChanged=@(() => StateHasChanged())
                 DefaultMetadataId=@ProjectAcronym
+                ProjectId=@_projectId
                 OnNewMetadataCreated=@AutoFillNewMetadataFields
                 OnExistingMetadataLoaded=@DetectIfCurrentItemIsInCatalog
             />
@@ -102,6 +104,7 @@ else
     private string _groupWithId;
 
     private ObjectMetadataEditor _reportMetadata;
+    private int _projectId;
 
     private bool _isSavingReport;
     private bool SaveReportDisabled => _isSavingReport || (_reportMetadata?.SaveDisabled ?? false);
@@ -228,6 +231,13 @@ else
         _siblingReports = await GetReportsForGrouping(_report);
         _groupWithId = await GetGroupedWith(_report);
         _catalogObjectLanguage = await _metadataService.GetCatalogObjectLanguage(PowerBiReportId.ToString()) ?? CatalogObjectLanguage.Bilingual;
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        var ctx = await _projectDbFactory.CreateDbContextAsync();
+        var project = await ctx.Projects.FirstOrDefaultAsync(p => p.Project_Acronym_CD == ProjectAcronym);
+        _projectId = project?.Project_ID ?? 0;
     }
 
 }

--- a/WebPortal/i18n/localization.fr.json
+++ b/WebPortal/i18n/localization.fr.json
@@ -187,7 +187,8 @@
   "DISCOVERY-CLASSIFICATION-TYPES": {
     "Unclassified": "Non classifié",
     "ProtectedA": "Protégé A",
-    "ProtectedB": "Protégé B"
+    "ProtectedB": "Protégé B",
+    "ProtectedC": "Protégé C"
   },
   "DISCOVERY-LANGUAGE-TYPES": {
     "Bilingual": "Bilingue",
@@ -238,6 +239,7 @@
   "PrivacyPolicy": "Politique de confidentialité",
   "Protected A": "Protégé A",
   "Protected B": "Protégé B",
+  "ProtectedC": "Protégé C",
   "Rename": "Renommer",
   "RequiredField": " = champs requis",
   "Role": "Role",

--- a/WebPortal/i18n/localization.json
+++ b/WebPortal/i18n/localization.json
@@ -194,7 +194,8 @@
   "DISCOVERY-CLASSIFICATION-TYPES": {
     "Unclassified": "Unclassified",
     "ProtectedA": "Protected A",
-    "ProtectedB": "Protected B"
+    "ProtectedB": "Protected B",
+    "ProtectedC": "Protected C"
   },
   "DISCOVERY-LANGUAGE-TYPES": {
     "Bilingual": "Bilingual",


### PR DESCRIPTION
- Includes refactors to the Security Classifications values (adding Protected C)
- Fixes to the PowerBI Cataloging per project.
- Editing the Initiative Metadata right after the Initiative is created by an Admin.